### PR TITLE
Fix timing issue

### DIFF
--- a/src/utils/hooks/useKubevirtDataPod/hooks/useKubevirtDataPodHealth.ts
+++ b/src/utils/hooks/useKubevirtDataPod/hooks/useKubevirtDataPodHealth.ts
@@ -1,24 +1,25 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
 
 import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { PROXY_KUBEVIRT_URL, PROXY_KUBEVIRT_URL_HEALTH_PATH } from '../utils/constants';
 
 const useKubevirtDataPodHealth = (): boolean | null => {
-  const alive = useRef<boolean>(null);
+  const [alive, setAlive] = useState<boolean>(null);
   useEffect(() => {
+    debugger;
     const fetch = async () => {
       try {
         const res = await consoleFetch(`${PROXY_KUBEVIRT_URL}${PROXY_KUBEVIRT_URL_HEALTH_PATH}`);
-        alive.current = res.ok;
+        setAlive(res.ok);
       } catch {
-        alive.current = false;
+        setAlive(false);
       }
     };
 
-    alive.current === null && fetch();
-  }, []);
+    alive === null && fetch();
+  }, [alive]);
 
-  return alive.current;
+  return alive;
 };
 export default useKubevirtDataPodHealth;


### PR DESCRIPTION
useKubevirtDataPodHealth was implemented using a ref. Changing the value of a ref will not trigger a new render.